### PR TITLE
bugfix: generate default id when array is empty

### DIFF
--- a/controllers/todos.js
+++ b/controllers/todos.js
@@ -42,7 +42,7 @@ module.exports = function(todos) {
           throw 'A valid description must be given';
         }
         // get a new ID (would be handled by proepr DB automatically)
-        var id = Math.max.apply(null, _.pluck(todos, 'id')) + 1;
+        var id = todos.length ? Math.max.apply(null, _.pluck(todos, 'id')) + 1 : 1;
         var todo = {
           id: id,
           done: req.body.done || false,


### PR DESCRIPTION
This fixes a bug I noticed. 
If the user deletes all To-Do's, all subsequent created To-Do's will not have ID's.
This change addresses this issue by restarting the ID's at 1 in this situation.