### PR TITLE
Add viewport meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>JumpCloud UI Assignment</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="./app.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
## What does this solve?

This pull request adds the viewport meta tag to the index.html in the jumpcloud-ui-assignment. For more discussion on this link, please refer to [this](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) MDN article.

## Is there anything particularly tricky?

No.

## How should this be tested?

By inspection. 

## Screenshots

## Reviews
- [ ] Primary Review (self)
- [ ] Secondary Review
- [ ] Tertiary Review
